### PR TITLE
Android Build Spport(Experimental)

### DIFF
--- a/Packages/com.styly.styly-spatial-layer-plugin/Editor/Menu/AssetMenu.cs
+++ b/Packages/com.styly.styly-spatial-layer-plugin/Editor/Menu/AssetMenu.cs
@@ -25,7 +25,7 @@ namespace Styly.VisionOs.Plugin
         }
 
 #if STYLY_EXPERIMENTAL
-        [MenuItem(@"Assets/STYLY/Build Prefab for VisionOS and Android(experimental)")]
+        [MenuItem(@"Assets/STYLY/Build Prefab for visionOS and Android(experimental)")]
         private static void BuildAndroidContent()
         {
             BuildContent(new[] { BuildTarget.VisionOS, BuildTarget.Android });
@@ -114,11 +114,12 @@ namespace Styly.VisionOs.Plugin
             assetBundleUtility.SwitchPlatform(buildTarget);
             ARBuildPreprocess.ARBuildPreprocessBuild(buildTarget);
             var buildResult = assetBundleUtility.Build(AssetBundleFileName, assetPath, outputPath, buildTarget);
-            var directoryName = VisionOsDirectoryName;
-            if (buildTarget == BuildTarget.Android)
+            var directoryName = buildTarget switch
             {
-                directoryName = AndroidDirectoryName;
-            }
+                BuildTarget.VisionOS => VisionOsDirectoryName,
+                BuildTarget.Android => AndroidDirectoryName,
+                _ => "UnknownPlatform"
+            };
             
             File.Delete(Path.Combine(outputPath, directoryName));
             File.Delete(Path.Combine(outputPath, $"{directoryName}.manifest"));

--- a/Packages/com.styly.styly-spatial-layer-plugin/Editor/Menu/AssetMenu.cs
+++ b/Packages/com.styly.styly-spatial-layer-plugin/Editor/Menu/AssetMenu.cs
@@ -51,11 +51,13 @@ namespace Styly.VisionOs.Plugin
             CreateThumbnailUtility.MakeThumbnail(assetPath, Path.Combine(outputPath, ThumbnailFileName));
             ExportBackupFileUtility.Export(assetPath, Path.Combine(outputPath, BackupDirectoryName));
 
-            var directoryName = VisionOsDirectoryName;
-            if (buildTarget == BuildTarget.Android)
+            var directoryName = buildTarget switch
             {
-                directoryName = AndroidDirectoryName;
-            }
+                BuildTarget.VisionOS => VisionOsDirectoryName,
+                BuildTarget.Android => AndroidDirectoryName,
+                _ => "UnknownPlatform"
+            };
+
             bool buildResult = BuildAssetBundle(assetPath, Path.Combine(outputPath, directoryName), buildTarget);
             if (buildResult == false)
             {

--- a/Packages/com.styly.styly-spatial-layer-plugin/Editor/Menu/AssetMenu.cs
+++ b/Packages/com.styly.styly-spatial-layer-plugin/Editor/Menu/AssetMenu.cs
@@ -24,11 +24,13 @@ namespace Styly.VisionOs.Plugin
             BuildContent(BuildTarget.VisionOS);
         }
 
+#if STYLY_EXPERIMENTAL
         [MenuItem(@"Assets/STYLY/Build Prefab for Android(experimental)")]
         private static void BuildAndroidContent()
         {
             BuildContent(BuildTarget.Android);
         }
+#endif
         
         private static void BuildContent(BuildTarget buildTarget)
         {

--- a/Packages/com.styly.styly-spatial-layer-plugin/Editor/Menu/AssetMenu.cs
+++ b/Packages/com.styly.styly-spatial-layer-plugin/Editor/Menu/AssetMenu.cs
@@ -21,18 +21,18 @@ namespace Styly.VisionOs.Plugin
         [MenuItem(@"Assets/STYLY/Build Prefab")]
         private static void BuildVisionOsContent()
         {
-            BuildContent(BuildTarget.VisionOS);
+            BuildContent(new[]{BuildTarget.VisionOS});
         }
 
 #if STYLY_EXPERIMENTAL
-        [MenuItem(@"Assets/STYLY/Build Prefab for Android(experimental)")]
+        [MenuItem(@"Assets/STYLY/Build Prefab for VisionOS and Android(experimental)")]
         private static void BuildAndroidContent()
         {
-            BuildContent(BuildTarget.Android);
+            BuildContent(new[] { BuildTarget.VisionOS, BuildTarget.Android });
         }
 #endif
         
-        private static void BuildContent(BuildTarget buildTarget)
+        private static void BuildContent(BuildTarget[] buildTargets)
         {
             isProcessing = true;
 
@@ -51,19 +51,23 @@ namespace Styly.VisionOs.Plugin
             CreateThumbnailUtility.MakeThumbnail(assetPath, Path.Combine(outputPath, ThumbnailFileName));
             ExportBackupFileUtility.Export(assetPath, Path.Combine(outputPath, BackupDirectoryName));
 
-            var directoryName = buildTarget switch
+            foreach (var buildTarget in buildTargets)
             {
-                BuildTarget.VisionOS => VisionOsDirectoryName,
-                BuildTarget.Android => AndroidDirectoryName,
-                _ => "UnknownPlatform"
-            };
+                var directoryName = buildTarget switch
+                {
+                    BuildTarget.VisionOS => VisionOsDirectoryName,
+                    BuildTarget.Android => AndroidDirectoryName,
+                    _ => "UnknownPlatform"
+                };
 
-            bool buildResult = BuildAssetBundle(assetPath, Path.Combine(outputPath, directoryName), buildTarget);
-            if (buildResult == false)
-            {
-                Directory.Delete(outputPath, true);
-                return;
+                bool buildResult = BuildAssetBundle(assetPath, Path.Combine(outputPath, directoryName), buildTarget);
+                if (buildResult == false)
+                {
+                    Directory.Delete(outputPath, true);
+                    return;
+                }
             }
+            
             GenerateMetadata(assetPath, Path.Combine(outputPath, MetaFileName));
 
             ZipFile.CreateFromDirectory(outputPath, $"{outputPath}_{assetFileNameWithoutExtension}.styly");

--- a/Packages/com.styly.styly-spatial-layer-plugin/Editor/Utility/AssetBundleUtility.cs
+++ b/Packages/com.styly.styly-spatial-layer-plugin/Editor/Utility/AssetBundleUtility.cs
@@ -16,6 +16,10 @@ namespace Styly.VisionOs.Plugin
             {
                 return EditorUserBuildSettings.SwitchActiveBuildTarget(BuildTargetGroup.VisionOS, BuildTarget.VisionOS);
             }
+            else if (buildTarget == BuildTarget.Android)
+            {
+                return EditorUserBuildSettings.SwitchActiveBuildTarget(BuildTargetGroup.Android, BuildTarget.Android);
+            }
             return false;
         }
 

--- a/Packages/com.styly.styly-spatial-layer-plugin/Tests/Editor/EditorStylyVisionOsPluginTest.cs
+++ b/Packages/com.styly.styly-spatial-layer-plugin/Tests/Editor/EditorStylyVisionOsPluginTest.cs
@@ -74,7 +74,7 @@ namespace Styly.VisionOs.Plugin
         }
 
         [Test]
-        public void BuildAssetBundle()
+        public void BuildAssetBundleForVisionOs()
         {
             var assetPath = $"Packages/{Config.PackageName}/Tests/Editor/TestData/Prefab/Cube.prefab";
             var assetBundleUtility = new AssetBundleUtility();
@@ -88,6 +88,24 @@ namespace Styly.VisionOs.Plugin
             Assert.That(result, Is.True);
             Assert.That(File.Exists( Path.Combine(outputPath, filename)), Is.True );
         }
+        
+        
+        [Test]
+        public void BuildAssetBundleForAndroid()
+        {
+            var assetPath = $"Packages/{Config.PackageName}/Tests/Editor/TestData/Prefab/Cube.prefab";
+            var assetBundleUtility = new AssetBundleUtility();
+            var result = assetBundleUtility.SwitchPlatform(BuildTarget.Android);
+            Assert.That(result, Is.True);
+
+            var filename = "assetbundle";
+            var outputPath = Path.Combine(Config.OutputPath,"Android");
+            result = assetBundleUtility.Build(filename, assetPath, outputPath, BuildTarget.Android);
+            
+            Assert.That(result, Is.True);
+            Assert.That(File.Exists( Path.Combine(outputPath, filename)), Is.True );
+        }
+
 
         [Test]
         public void CreateBuildInfo()

--- a/Packages/com.styly.styly-spatial-layer-plugin/Tests/Editor/EditorStylyVisionOsPluginTest.cs
+++ b/Packages/com.styly.styly-spatial-layer-plugin/Tests/Editor/EditorStylyVisionOsPluginTest.cs
@@ -36,6 +36,19 @@ namespace Styly.VisionOs.Plugin
             Assert.That(result, Is.True);
             Assert.That(EditorUserBuildSettings.activeBuildTarget, Is.EqualTo(BuildTarget.VisionOS));
         }
+        
+        [Test]
+        public void SwitchPlatformToAndroid()
+        {
+            EditorUserBuildSettings.SwitchActiveBuildTarget(BuildTargetGroup.Standalone, BuildTarget.StandaloneOSX);
+            Assert.That(EditorUserBuildSettings.activeBuildTarget, Is.EqualTo(BuildTarget.StandaloneOSX));
+            
+            var assetBundleUtility = new AssetBundleUtility();
+            var result = assetBundleUtility.SwitchPlatform(BuildTarget.Android);
+            
+            Assert.That(result, Is.True);
+            Assert.That(EditorUserBuildSettings.activeBuildTarget, Is.EqualTo(BuildTarget.Android));
+        }
 
         [Test]
         public void CreateThumbnail()


### PR DESCRIPTION
I added Android build support for experimental purposes.

###  Usage
1. Add the Scripting Define Symbol `STYLY_EXPERIMENTAL` to activate the experimental menu.
2. Right-click a prefab and select [STYLY] > [Build prefab for visionOS and Android (experimental)].
<img width="614" alt="image" src="https://github.com/user-attachments/assets/3a7380a3-411d-45f4-abf7-898da3b4ccb0" />

### Future support
I think a UI for selecting the build target is necessary.