### PR TITLE
Error handle of register package

### DIFF
--- a/Packages/com.styly.styly-spatial-layer-plugin/Editor/Initialization/DeleteCustomPackageAndRegisterPackageName.cs
+++ b/Packages/com.styly.styly-spatial-layer-plugin/Editor/Initialization/DeleteCustomPackageAndRegisterPackageName.cs
@@ -80,16 +80,24 @@ namespace Styly
         /// <returns></returns>
         static string MoveDirectoryToTempPath(string sourcePath)
         {
-            // Create a unique temporary path to avoid name collisions
-            var workDirectoryPath = FileUtil.GetUniqueTempPathInProject();
-            Directory.CreateDirectory(workDirectoryPath);
-            string tempPath = Path.Combine(
-                workDirectoryPath,
-                $"{Path.GetFileName(sourcePath)}_{Guid.NewGuid():N}"
-            );
-            FileUtil.CopyFileOrDirectory(sourcePath, tempPath);
-            Directory.Delete(sourcePath, true);
-            return tempPath;
+            try
+            {
+                // Create a unique temporary path to avoid name collisions
+                var workDirectoryPath = FileUtil.GetUniqueTempPathInProject();
+                Directory.CreateDirectory(workDirectoryPath);
+                string tempPath = Path.Combine(
+                    workDirectoryPath,
+                    $"{Path.GetFileName(sourcePath)}_{Guid.NewGuid():N}"
+                );
+                FileUtil.CopyFileOrDirectory(sourcePath, tempPath);
+                Directory.Delete(sourcePath, true);
+                return tempPath;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"Failed to move directory '{sourcePath}' to a temporary path. Exception: {ex.Message}");
+                return null; // Return null to indicate failure
+            }
         }
 
 

--- a/Packages/com.styly.styly-spatial-layer-plugin/Editor/Initialization/DeleteCustomPackageAndRegisterPackageName.cs
+++ b/Packages/com.styly.styly-spatial-layer-plugin/Editor/Initialization/DeleteCustomPackageAndRegisterPackageName.cs
@@ -48,6 +48,12 @@ namespace Styly
                 }
                 // Cleanup the temporary directory
                 if (Directory.Exists(tempPath)) { Directory.Delete(tempPath, true); }
+                // Delete the parent temporary directory if it exists and is empty
+                var workDirectoryPath = Path.GetDirectoryName(tempPath);
+                if (Directory.Exists(workDirectoryPath) && !Directory.EnumerateFileSystemEntries(workDirectoryPath).Any())
+                {
+                    Directory.Delete(workDirectoryPath, true);
+                }
             }
         }
 

--- a/Packages/com.styly.styly-spatial-layer-plugin/Editor/Initialization/DeleteCustomPackageAndRegisterPackageName.cs
+++ b/Packages/com.styly.styly-spatial-layer-plugin/Editor/Initialization/DeleteCustomPackageAndRegisterPackageName.cs
@@ -6,6 +6,7 @@ using System.IO;
 using Newtonsoft.Json;
 using System.Linq;
 using Styly.VisionOs.Plugin;
+using System;
 
 namespace Styly
 {
@@ -28,13 +29,21 @@ namespace Styly
             string MyPackagePath = MyPackageInfo.resolvedPath;
             string MyPackageSource = MyPackageInfo.source.ToString();
 
+            // If the package is installed with files in Packages and not managed with Git, delete the package folder and register the package using OpenUPM.
             if (MyPackageSource == "Embedded")
             {
-                // Delete the package folder
-                if (Directory.Exists(MyPackagePath)) { Directory.Delete(MyPackagePath, true); }
+                string tempPath = null;
+                // Delete the package folder (Move the directory to a temporary path for fallback)
+                if (Directory.Exists(MyPackagePath)) { tempPath = MoveDirectoryToTempPath(MyPackagePath); }
 
-                // Add the package to the project
-                PackageManagerUtility.AddUnityPackage(MyPackageName + "@" + MyPackageVersion);
+                // Add the package to the project using OpenUPM
+                if (!PackageManagerUtility.AddUnityPackage(MyPackageName + "@" + MyPackageVersion))
+                {
+                    // If the package was not added successfully, restore the directory from the temporary path
+                    string originalPath = Path.Combine(Path.GetDirectoryName(MyPackagePath), Path.GetFileName(tempPath));
+                    Directory.Move(tempPath, originalPath);
+                    Debug.LogWarning($"{MyPackageName}: Failed to switch the package source to OpenUPM. The change will be retried automatically next time.");
+                }
             }
         }
 
@@ -58,6 +67,22 @@ namespace Styly
             if (Directory.Exists(Path.Combine(ProjectRootDirectry.FullName, ".git")) || Directory.Exists(Path.Combine(ProjectRootDirectry.Parent.FullName, ".git"))) { return true; }
 
             return false;
+        }
+
+        /// <summary>
+        /// Move the directory to a temporary path.
+        /// </summary>
+        /// <param name="sourcePath"></param>
+        /// <returns></returns>
+        static string MoveDirectoryToTempPath(string sourcePath)
+        {
+            // Create a unique temporary path to avoid name collisions
+            string tempPath = Path.Combine(
+                Path.GetTempPath(),
+                $"{Path.GetFileName(sourcePath)}_{Guid.NewGuid():N}"
+            );
+            Directory.Move(sourcePath, tempPath);
+            return tempPath;
         }
 
 

--- a/Packages/com.styly.styly-spatial-layer-plugin/Editor/Initialization/DeleteCustomPackageAndRegisterPackageName.cs
+++ b/Packages/com.styly.styly-spatial-layer-plugin/Editor/Initialization/DeleteCustomPackageAndRegisterPackageName.cs
@@ -32,9 +32,9 @@ namespace Styly
             // If the package is installed with files in Packages and not managed with Git, delete the package folder and register the package using OpenUPM.
             if (MyPackageSource == "Embedded")
             {
-                string tempPath = null;
                 // Delete the package folder (Move the directory to a temporary path for fallback)
-                if (Directory.Exists(MyPackagePath)) { tempPath = MoveDirectoryToTempPath(MyPackagePath); }
+                if (!Directory.Exists(MyPackagePath)) { return; }
+                string tempPath = MoveDirectoryToTempPath(MyPackagePath);
 
                 // Add the package to the project using OpenUPM
                 bool result = PackageManagerUtility.AddUnityPackage(MyPackageName + "@" + MyPackageVersion);
@@ -43,22 +43,11 @@ namespace Styly
                 if (!result)
                 {
                     // If the package was not added successfully, restore the directory from the temporary path
-                    if (tempPath != null)
-                    {
-                        string originalPath = Path.Combine(Path.GetDirectoryName(MyPackagePath), Path.GetFileName(tempPath));
-                        Directory.Move(tempPath, originalPath);
-                        Debug.LogError($"{MyPackageName}: Failed to switch the package source to OpenUPM. This will be retried automatically next time.");
-                    }
-                    else
-                    {
-                        Debug.LogError($"{MyPackageName}: Failed to switch the package source to OpenUPM, and no temporary path was available for fallback.");
-                    }
+                    FileUtil.CopyFileOrDirectory(tempPath, MyPackagePath);
+                    Debug.LogError($"{MyPackageName}: Failed to switch the package source to OpenUPM. This will be retried automatically next time.");
                 }
-                else
-                {
-                    // If the package was added successfully, delete the temporary path
-                    if (Directory.Exists(tempPath)) { Directory.Delete(tempPath, true); }
-                }
+                // Cleanup the temporary directory
+                if (Directory.Exists(tempPath)) { Directory.Delete(tempPath, true); }
             }
         }
 

--- a/Packages/com.styly.styly-spatial-layer-plugin/Editor/Initialization/DeleteCustomPackageAndRegisterPackageName.cs
+++ b/Packages/com.styly.styly-spatial-layer-plugin/Editor/Initialization/DeleteCustomPackageAndRegisterPackageName.cs
@@ -45,7 +45,7 @@ namespace Styly
                     // If the package was not added successfully, restore the directory from the temporary path
                     string originalPath = Path.Combine(Path.GetDirectoryName(MyPackagePath), Path.GetFileName(tempPath));
                     Directory.Move(tempPath, originalPath);
-                    Debug.LogWarning($"{MyPackageName}: Failed to switch the package source to OpenUPM. The change will be retried automatically next time.");
+                    Debug.LogError($"{MyPackageName}: Failed to switch the package source to OpenUPM. This will be retried automatically next time.");
                 }
                 else
                 {

--- a/Packages/com.styly.styly-spatial-layer-plugin/Editor/Initialization/DeleteCustomPackageAndRegisterPackageName.cs
+++ b/Packages/com.styly.styly-spatial-layer-plugin/Editor/Initialization/DeleteCustomPackageAndRegisterPackageName.cs
@@ -37,12 +37,20 @@ namespace Styly
                 if (Directory.Exists(MyPackagePath)) { tempPath = MoveDirectoryToTempPath(MyPackagePath); }
 
                 // Add the package to the project using OpenUPM
-                if (!PackageManagerUtility.AddUnityPackage(MyPackageName + "@" + MyPackageVersion))
+                bool result = PackageManagerUtility.AddUnityPackage(MyPackageName + "@" + MyPackageVersion);
+
+                // Fallback and cleanup
+                if (!result)
                 {
                     // If the package was not added successfully, restore the directory from the temporary path
                     string originalPath = Path.Combine(Path.GetDirectoryName(MyPackagePath), Path.GetFileName(tempPath));
                     Directory.Move(tempPath, originalPath);
                     Debug.LogWarning($"{MyPackageName}: Failed to switch the package source to OpenUPM. The change will be retried automatically next time.");
+                }
+                else
+                {
+                    // If the package was added successfully, delete the temporary path
+                    if (Directory.Exists(tempPath)) { Directory.Delete(tempPath, true); }
                 }
             }
         }
@@ -77,11 +85,14 @@ namespace Styly
         static string MoveDirectoryToTempPath(string sourcePath)
         {
             // Create a unique temporary path to avoid name collisions
+            var workDirectoryPath = FileUtil.GetUniqueTempPathInProject();
+            Directory.CreateDirectory(workDirectoryPath);
             string tempPath = Path.Combine(
-                Path.GetTempPath(),
+                workDirectoryPath,
                 $"{Path.GetFileName(sourcePath)}_{Guid.NewGuid():N}"
             );
-            Directory.Move(sourcePath, tempPath);
+            FileUtil.CopyFileOrDirectory(sourcePath, tempPath);
+            Directory.Delete(sourcePath, true);
             return tempPath;
         }
 

--- a/Packages/com.styly.styly-spatial-layer-plugin/Editor/Initialization/DeleteCustomPackageAndRegisterPackageName.cs
+++ b/Packages/com.styly.styly-spatial-layer-plugin/Editor/Initialization/DeleteCustomPackageAndRegisterPackageName.cs
@@ -43,9 +43,16 @@ namespace Styly
                 if (!result)
                 {
                     // If the package was not added successfully, restore the directory from the temporary path
-                    string originalPath = Path.Combine(Path.GetDirectoryName(MyPackagePath), Path.GetFileName(tempPath));
-                    Directory.Move(tempPath, originalPath);
-                    Debug.LogError($"{MyPackageName}: Failed to switch the package source to OpenUPM. This will be retried automatically next time.");
+                    if (tempPath != null)
+                    {
+                        string originalPath = Path.Combine(Path.GetDirectoryName(MyPackagePath), Path.GetFileName(tempPath));
+                        Directory.Move(tempPath, originalPath);
+                        Debug.LogError($"{MyPackageName}: Failed to switch the package source to OpenUPM. This will be retried automatically next time.");
+                    }
+                    else
+                    {
+                        Debug.LogError($"{MyPackageName}: Failed to switch the package source to OpenUPM, and no temporary path was available for fallback.");
+                    }
                 }
                 else
                 {

--- a/Packages/com.styly.styly-spatial-layer-plugin/Editor/Initialization/DeleteCustomPackageAndRegisterPackageName.cs
+++ b/Packages/com.styly.styly-spatial-layer-plugin/Editor/Initialization/DeleteCustomPackageAndRegisterPackageName.cs
@@ -48,12 +48,7 @@ namespace Styly
                 }
                 // Cleanup the temporary directory
                 if (Directory.Exists(tempPath)) { Directory.Delete(tempPath, true); }
-                // Delete the parent temporary directory if it exists and is empty
-                var workDirectoryPath = Path.GetDirectoryName(tempPath);
-                if (Directory.Exists(workDirectoryPath) && !Directory.EnumerateFileSystemEntries(workDirectoryPath).Any())
-                {
-                    Directory.Delete(workDirectoryPath, true);
-                }
+                if (Directory.Exists(Path.GetDirectoryName(tempPath)) && !Directory.EnumerateFileSystemEntries(Path.GetDirectoryName(tempPath)).Any()){Directory.Delete(Path.GetDirectoryName(tempPath), true);}
             }
         }
 

--- a/Packages/com.styly.styly-spatial-layer-plugin/Editor/Utility/PackageManagerUtility.cs
+++ b/Packages/com.styly.styly-spatial-layer-plugin/Editor/Utility/PackageManagerUtility.cs
@@ -47,12 +47,11 @@ namespace Styly.VisionOs.Plugin
         }
 
         /// <summary>
-        /// Add a Unity package to the project
+        /// Add a Unity package by its name and version.
         /// </summary>
-        /// <param name="packageName">
-        /// Example: com.company.packaganame or com.company.packaganame@0.1.1
-        /// </param>
-        public static void AddUnityPackage(string packageNameWithVersion)
+        /// <param name="packageNameWithVersion"></param>
+        /// <returns></returns>
+        public static bool AddUnityPackage(string packageNameWithVersion)
         {
             // Separate the package name and version
             var packageName = packageNameWithVersion.Split('@')[0];
@@ -67,7 +66,12 @@ namespace Styly.VisionOs.Plugin
             // Add the package
             var request = UnityEditor.PackageManager.Client.Add(packageNameWithVersion);
             while (!request.IsCompleted) { }
-            if (request.Error != null) { Debug.LogError(request.Error.message); }
+            if (request.Error != null)
+            {
+                Debug.LogError(request.Error.message);
+                return false;
+            }
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
This pull request introduces enhancements to the package management logic for Unity projects by improving error handling, adding fallback mechanisms, and refining utility methods. The changes aim to ensure smoother transitions when switching package sources and provide better reliability in handling package-related operations.

### Enhancements to package management logic:

* **Fallback mechanism for package source switching**:
  - Updated `FuncOfDeleteCustomPackageAndRegisterPackageName` to include a fallback mechanism. If switching the package source to OpenUPM fails, the original package directory is restored from a temporary path, and an error message is logged.
  - Added a new helper method `MoveDirectoryToTempPath` to move a directory to a unique temporary path for fallback purposes.

### Refinements to utility methods:

* **Improved error handling in package addition**:
  - Modified `AddUnityPackage` in `PackageManagerUtility` to return a `bool` indicating success or failure, instead of relying solely on logging errors. This enables better control flow in dependent methods. [[1]](diffhunk://#diff-85729308f5be699c548bb5595aacfa3730ab1e3558f3f5ae07f53f4bd8c75511L50-R54) [[2]](diffhunk://#diff-85729308f5be699c548bb5595aacfa3730ab1e3558f3f5ae07f53f4bd8c75511L70-R74)

### Codebase maintenance:

* **Added missing namespace import**:
  - Included the `System` namespace in `DeleteCustomPackageAndRegisterPackageName.cs` to support new functionality.

Close https://github.com/styly-dev/STYLY-Spatial-Layer-Plugin/issues/102